### PR TITLE
Fix the memory amount on PCF manifest 

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: "aad"
-  memory: 512M
+  memory: 650M
   instances: 1
   buildpack: https://github.com/cloudfoundry/java-buildpack.git
   env:


### PR DESCRIPTION
Set a PCF memory size in the manifest that spring boot will work with.
    [atomist:generated]