### PR TITLE
Fix the memory amount on PCF manifest 

### DIFF
--- a/outfile
+++ b/outfile
@@ -1,0 +1,1 @@
+undefined


### PR DESCRIPTION
Set a PCF memory size in the manifest that spring boot will work with.
    [atomist:generated]