### PR TITLE
Fix the memory amount on PCF manifest 

### DIFF
--- a/outfile
+++ b/outfile
@@ -1,0 +1,8 @@
+total 80
+-rw-r--r--  1 matt  staff  11357 Nov 16 12:38 LICENSE
+-rw-r--r--  1 matt  staff    735 Nov 16 12:38 README.md
+-rw-r--r--  1 matt  staff    161 Nov 16 12:38 manifest.yml
+-rwxr-xr-x  1 matt  staff   6468 Nov 16 12:38 mvnw
+-rw-r--r--  1 matt  staff   4994 Nov 16 12:38 mvnw.cmd
+-rw-r--r--  1 matt  staff   2495 Nov 16 12:38 pom.xml
+drwxr-xr-x  4 matt  staff    128 Nov 16 12:38 src


### PR DESCRIPTION
Set a PCF memory size in the manifest that spring boot will work with.
    [atomist:generated]